### PR TITLE
Harden OTP service: require shared-secret auth, limit verify attempts…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ GUILD_ID=
 VERIFIED_ROLE_ID=
 UNVERIFIED_ROLE_ID=
 OTP_SERVICE_URL=http://localhost:3001
+# Shared secret between the bot and the OTP service.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+OTP_SERVICE_KEY=

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -22,7 +22,21 @@ const {
   setGuildConfig,
 } = require('./db');
 
-const { DISCORD_TOKEN, OTP_SERVICE_URL = 'http://localhost:3001' } = process.env;
+const {
+  DISCORD_TOKEN,
+  OTP_SERVICE_URL = 'http://localhost:3001',
+  OTP_SERVICE_KEY,
+} = process.env;
+
+if (!OTP_SERVICE_KEY) {
+  console.error('OTP_SERVICE_KEY missing — bot cannot authenticate to OTP service.');
+  process.exit(1);
+}
+
+const otpHeaders = {
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${OTP_SERVICE_KEY}`,
+};
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers],
@@ -177,7 +191,7 @@ client.on('interactionCreate', async (interaction) => {
         try {
           const res = await fetch(`${OTP_SERVICE_URL}/send`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: otpHeaders,
             body: JSON.stringify({ discordId: userId, email }),
           });
           const data = await res.json();
@@ -226,7 +240,7 @@ client.on('interactionCreate', async (interaction) => {
         try {
           const res = await fetch(`${OTP_SERVICE_URL}/verify`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: otpHeaders,
             body: JSON.stringify({ discordId: userId, code: input }),
           });
           data = await res.json();
@@ -239,6 +253,7 @@ client.on('interactionCreate', async (interaction) => {
             no_pending: 'No pending verification. Run `/verify` first.',
             expired: 'Code expired. Run `/verify` again.',
             wrong_code: 'Wrong code. Try again.',
+            too_many_attempts: 'Too many wrong codes. Run `/verify` again to get a new code.',
           };
           return interaction.reply({
             content: messages[data.reason] ?? 'Verification failed. Try again.',
@@ -379,7 +394,7 @@ client.on('interactionCreate', async (interaction) => {
         try {
           const res = await fetch(`${OTP_SERVICE_URL}/send`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: otpHeaders,
             body: JSON.stringify({ discordId: userId, email }),
           });
           const data = await res.json();
@@ -437,7 +452,7 @@ client.on('interactionCreate', async (interaction) => {
         try {
           const res = await fetch(`${OTP_SERVICE_URL}/verify`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: otpHeaders,
             body: JSON.stringify({ discordId: userId, code: input }),
           });
           data = await res.json();
@@ -450,6 +465,7 @@ client.on('interactionCreate', async (interaction) => {
             no_pending: 'No pending verification. Start verification again from the panel.',
             expired: 'Code expired. Start verification again from the panel.',
             wrong_code: 'Wrong code. Try again.',
+            too_many_attempts: 'Too many wrong codes. Start verification again from the panel.',
           };
           return interaction.reply({
             content: messages[data.reason] ?? 'Verification failed. Try again.',

--- a/src/otp-service/index.js
+++ b/src/otp-service/index.js
@@ -1,33 +1,81 @@
 require('dotenv').config();
+const crypto = require('crypto');
 const express = require('express');
-const { checkRateLimit, createOtp, validateOtp } = require('./otp');
+const {
+  generateCode,
+  canSend,
+  commitSend,
+  storeOtp,
+  validateOtp,
+} = require('./otp');
 const { sendOtp } = require('./email');
 
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: '1kb' }));
 
 const port = process.env.OTP_SERVICE_PORT || 3001;
+const serviceKey = process.env.OTP_SERVICE_KEY;
+
+if (!serviceKey || serviceKey.length < 32) {
+  console.error('OTP_SERVICE_KEY missing or too short (need >=32 chars). Refusing to start.');
+  process.exit(1);
+}
+
+const expectedAuthHash = crypto
+  .createHash('sha256')
+  .update(`Bearer ${serviceKey}`)
+  .digest();
+
+function isAuthed(req) {
+  const header = req.get('authorization');
+  if (!header) return false;
+  const providedHash = crypto.createHash('sha256').update(header).digest();
+  return crypto.timingSafeEqual(providedHash, expectedAuthHash);
+}
+
+function isNonEmptyString(v, maxLen) {
+  return typeof v === 'string' && v.length > 0 && v.length <= maxLen;
+}
+
+app.use((req, res, next) => {
+  if (!isAuthed(req)) {
+    return res.status(401).json({ ok: false, reason: 'unauthorized' });
+  }
+  next();
+});
 
 app.post('/send', async (req, res) => {
-  const { discordId, email } = req.body;
+  const { discordId, email } = req.body ?? {};
 
-  if (!checkRateLimit(discordId)) {
+  if (!isNonEmptyString(discordId, 64) || !isNonEmptyString(email, 320)) {
+    return res.status(400).json({ ok: false, reason: 'bad_request' });
+  }
+
+  if (!canSend(discordId)) {
     return res.json({ ok: false, reason: 'rate_limited' });
   }
 
-  const code = createOtp(discordId, email);
+  const code = generateCode();
 
   try {
     await sendOtp(email, code);
-    return res.json({ ok: true });
   } catch (err) {
-    console.error('sendOtp failed:', err);
+    console.error('sendOtp failed:', err.message);
     return res.json({ ok: false, reason: 'send_failed' });
   }
+
+  storeOtp(discordId, email, code);
+  commitSend(discordId);
+  return res.json({ ok: true });
 });
 
 app.post('/verify', (req, res) => {
-  const { discordId, code } = req.body;
+  const { discordId, code } = req.body ?? {};
+
+  if (!isNonEmptyString(discordId, 64) || !isNonEmptyString(code, 16)) {
+    return res.status(400).json({ ok: false, reason: 'bad_request' });
+  }
+
   const result = validateOtp(discordId, code);
   return res.json(result);
 });

--- a/src/otp-service/otp.js
+++ b/src/otp-service/otp.js
@@ -1,37 +1,44 @@
 const crypto = require('crypto');
 
 const OTP_TTL = 10 * 60 * 1000;
-const MAX_ATTEMPTS = 3;
-const ATTEMPT_WINDOW = 60 * 60 * 1000;
+const MAX_SENDS = 3;
+const SEND_WINDOW = 60 * 60 * 1000;
+const MAX_VERIFY_ATTEMPTS = 5;
 
 const store = new Map();
-const attempts = new Map();
+const sendCounters = new Map();
 
 function generateCode() {
-  return String(crypto.randomInt(100000, 999999));
+  return String(crypto.randomInt(100000, 1000000)).padStart(6, '0');
 }
 
-function checkRateLimit(userId) {
+function pruneSendCounter(userId) {
+  const entry = sendCounters.get(userId);
+  if (entry && Date.now() >= entry.resetAt) {
+    sendCounters.delete(userId);
+    return null;
+  }
+  return entry || null;
+}
+
+function canSend(userId) {
+  const entry = pruneSendCounter(userId);
+  return !entry || entry.count < MAX_SENDS;
+}
+
+function commitSend(userId) {
   const now = Date.now();
-  const entry = attempts.get(userId);
-
-  if (!entry || now >= entry.resetAt) {
-    attempts.set(userId, { count: 1, resetAt: now + ATTEMPT_WINDOW });
-    return true;
+  const entry = pruneSendCounter(userId);
+  if (!entry) {
+    sendCounters.set(userId, { count: 1, resetAt: now + SEND_WINDOW });
+  } else {
+    entry.count += 1;
   }
-
-  if (entry.count >= MAX_ATTEMPTS) {
-    return false;
-  }
-
-  entry.count += 1;
-  return true;
 }
 
-function createOtp(userId, email) {
-  const code = generateCode();
+function storeOtp(userId, email, code) {
   const expiresAt = Date.now() + OTP_TTL;
-  store.set(userId, { code, email, expiresAt });
+  store.set(userId, { code, email, expiresAt, attempts: 0 });
 
   const timer = setTimeout(() => {
     const current = store.get(userId);
@@ -40,8 +47,6 @@ function createOtp(userId, email) {
     }
   }, OTP_TTL);
   timer.unref();
-
-  return code;
 }
 
 function validateOtp(userId, inputCode) {
@@ -55,7 +60,19 @@ function validateOtp(userId, inputCode) {
     return { ok: false, reason: 'expired' };
   }
 
-  if (entry.code !== inputCode) {
+  entry.attempts += 1;
+
+  const stored = Buffer.from(entry.code, 'utf8');
+  const provided = Buffer.from(inputCode, 'utf8');
+  const matches =
+    stored.length === provided.length &&
+    crypto.timingSafeEqual(stored, provided);
+
+  if (!matches) {
+    if (entry.attempts >= MAX_VERIFY_ATTEMPTS) {
+      store.delete(userId);
+      return { ok: false, reason: 'too_many_attempts' };
+    }
     return { ok: false, reason: 'wrong_code' };
   }
 
@@ -63,4 +80,10 @@ function validateOtp(userId, inputCode) {
   return { ok: true, email: entry.email };
 }
 
-module.exports = { generateCode, checkRateLimit, createOtp, validateOtp };
+module.exports = {
+  generateCode,
+  canSend,
+  commitSend,
+  storeOtp,
+  validateOtp,
+};


### PR DESCRIPTION
Don’t save the OTP unless the email actually sends.

- OTP service blocks requests if there’s no Authorization: Bearer <key>
- (uses hashing + timingSafeEqual, constant-time check)
- /verify locks you out after 5 wrong tries for the same OTP
- OTP only gets saved after sendOtp works; resend failures don’t waste the rate limit anymore
- All endpoints check input type and length