### PR TITLE
read me changes and ci/cd fixes 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 coverage/
 .DS_Store
 *Cursor_runbook.md
+HOW_IT_WORKS.md
+CODE_GUIDE.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gopherfy
 
-[![CI](https://github.com/ravindu-ranasinghe/umn-discord-verification/actions/workflows/ci.yml/badge.svg)](https://github.com/ravindu-ranasinghe/umn-discord-verification/actions/workflows/ci.yml)
+[![CI](https://github.com/ravindu-ranasinghe/Gopherfy/actions/workflows/ci.yml/badge.svg)](https://github.com/ravindu-ranasinghe/Gopherfy/actions/workflows/ci.yml)
 
 A Discord verification bot that confirms a member owns a real `@umn.edu`
 email address, remembers them, and auto-assigns the "verified" role in
@@ -39,7 +39,7 @@ defined in [src/bot/db.js](src/bot/db.js):
 ```sql
 CREATE TABLE verified_users (
   discord_id  TEXT PRIMARY KEY,
-  email       TEXT UNIQUE,
+  email_hmac  TEXT UNIQUE,
   verified_at INTEGER
 );
 
@@ -53,9 +53,13 @@ CREATE TABLE guild_config (
 
 `verified_users` is the cross-server memory. `discord_id` is the
 primary key so each Discord account can only ever be linked to one
-email, and `email UNIQUE` ensures the reverse — one UMN identity can
-only verify one Discord account. Attempts to reuse an email on a second
-account are rejected by the bot before an OTP is even sent.
+email, and `email_hmac UNIQUE` ensures the reverse — one UMN identity
+can only verify one Discord account. Gopherfy never stores the
+plaintext email address; it stores an HMAC-SHA256 digest
+(`OTP_HMAC_KEY`) so the database contains no PII. Attempts to reuse an
+email on a second account are still caught — the bot computes the HMAC
+of the submitted address and checks for a collision before an OTP is
+even sent.
 
 `guild_config` stores per-server settings — which role to grant after
 verification — set by an admin running `/setup`.
@@ -174,16 +178,34 @@ old version cannot change behavior silently. Gopherfy defaults to
 
 ## Commands
 
-| Command                       | Who           | What                                           |
-| ----------------------------- | ------------- | ---------------------------------------------- |
-| `/setup verified-role:<role>` | Server admins | One-time per-server config                     |
-| `/verify-panel`               | Mods          | Post the button-driven verification panel      |
-| `/verify [email]`             | Everyone      | Start verification (slash-command flow)        |
-| `/code <digits>`              | Everyone      | Submit the 6-digit code                        |
-| `/whois <user>`               | Mods          | Look up which UMN email a member verified with |
+| Command                       | Who           | What                                                      |
+| ----------------------------- | ------------- | --------------------------------------------------------- |
+| `/setup verified-role:<role>` | Server admins | One-time per-server config                                |
+| `/verify-panel`               | Mods          | Post the button-driven verification panel                 |
+| `/verify [email]`             | Everyone      | Start verification (slash-command flow)                   |
+| `/code <digits>`              | Everyone      | Submit the 6-digit code                                   |
+| `/whois <user>`               | Mods          | Look up which UMN email a member verified with            |
+| `/whois-audit`                | Server admins | Show recent `/whois` lookups grouped by moderator         |
+| `/forget-me`                  | Everyone      | Delete your verification record and remove verified roles |
 
 Most users go through the panel's **Start verification** / **Submit
 code** buttons rather than the slash commands directly.
+
+## Development
+
+**Local CI parity** — before pushing, run:
+
+```bash
+npm run verify
+```
+
+This runs `npm ci → lint → format:check → test --ci → audit`, mirroring
+the three CI jobs exactly. If it's green locally it will be green in CI.
+
+A **pre-push hook** (`.husky/pre-push`) runs `npm run verify`
+automatically on every `git push`, blocking the push if any check fails.
+Use `git push --no-verify` to bypass when genuinely needed (e.g. a
+work-in-progress draft push).
 
 ## Authors
 

--- a/src/bot/__tests__/factories/interaction.js
+++ b/src/bot/__tests__/factories/interaction.js
@@ -51,6 +51,7 @@ function buildBaseInteraction({
     deferred: false,
     reply: jest.fn().mockResolvedValue(),
     deferReply: jest.fn().mockResolvedValue(),
+    deferUpdate: jest.fn().mockResolvedValue(),
     editReply: jest.fn().mockResolvedValue(),
     update: jest.fn().mockResolvedValue(),
     showModal: jest.fn().mockResolvedValue(),

--- a/src/bot/__tests__/handlers/code.test.js
+++ b/src/bot/__tests__/handlers/code.test.js
@@ -27,7 +27,7 @@ describe('/code handler', () => {
     await code.handle(interaction, deps);
     expect(deps.db.addVerifiedHmac).toHaveBeenCalledWith('user1', 'hmac:a@umn.edu');
     expect(deps.applyGuildVerificationRoles).toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Verified! Welcome') }),
     );
   });
@@ -40,7 +40,7 @@ describe('/code handler', () => {
         .mockResolvedValue({ json: async () => ({ ok: false, reason: 'wrong_code' }) }),
     });
     await code.handle(interaction, deps);
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Wrong code') }),
     );
     expect(deps.db.addVerifiedHmac).not.toHaveBeenCalled();
@@ -54,7 +54,7 @@ describe('/code handler', () => {
         .mockResolvedValue({ json: async () => ({ ok: false, reason: 'expired' }) }),
     });
     await code.handle(interaction, deps);
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('expired') }),
     );
   });
@@ -67,7 +67,7 @@ describe('/code handler', () => {
         .mockResolvedValue({ json: async () => ({ ok: false, reason: 'too_many_attempts' }) }),
     });
     await code.handle(interaction, deps);
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Too many wrong codes') }),
     );
   });
@@ -85,7 +85,7 @@ describe('/code handler', () => {
     });
     await code.handle(interaction, deps);
     expect(deps.db.addVerifiedHmac).toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('role assignment failed'),
       }),
@@ -103,7 +103,7 @@ describe('/code handler', () => {
     });
     await code.handle(interaction, deps);
     expect(deps.db.addVerifiedHmac).toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('could not fetch your member record'),
       }),
@@ -116,7 +116,7 @@ describe('/code handler', () => {
       postToOtpService: jest.fn().mockRejectedValue(new Error('econnrefused')),
     });
     await code.handle(interaction, deps);
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Failed to reach') }),
     );
   });
@@ -131,7 +131,7 @@ describe('/code handler', () => {
     });
     await code.handle(interaction, deps);
     expect(deps.postToOtpService).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('already verified') }),
     );
   });

--- a/src/bot/__tests__/handlers/forget-me.test.js
+++ b/src/bot/__tests__/handlers/forget-me.test.js
@@ -56,7 +56,7 @@ describe('forget_me_confirm button', () => {
     const g1 = cache.get('g1');
     expect(g1.members.fetch).toHaveBeenCalledWith('user1');
     expect(g1._member.roles.remove).toHaveBeenCalledWith('role-g1');
-    expect(interaction.update).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('has been deleted'),
         components: [],
@@ -95,7 +95,7 @@ describe('forget_me_confirm button', () => {
     expect(deps.db.deleteVerified).toHaveBeenCalled();
     expect(deps.db.insertDeletionAudit).toHaveBeenCalled();
     expect(goodMember.roles.remove).toHaveBeenCalled();
-    expect(interaction.update).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalled();
   });
 });
 

--- a/src/bot/__tests__/handlers/modals.test.js
+++ b/src/bot/__tests__/handlers/modals.test.js
@@ -83,7 +83,7 @@ describe('umn_verify_email_modal', () => {
     });
     await modals.handleEmailModal(interaction, deps);
     expect(deps.postToOtpService).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('verified before') }),
     );
   });
@@ -154,7 +154,7 @@ describe('umn_verify_code_modal', () => {
     await modals.handleCodeModal(interaction, deps);
     expect(deps.db.addVerifiedHmac).toHaveBeenCalled();
     expect(deps.applyGuildVerificationRoles).toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Verified! Welcome') }),
     );
   });
@@ -170,7 +170,7 @@ describe('umn_verify_code_modal', () => {
         .mockResolvedValue({ json: async () => ({ ok: false, reason: 'wrong_code' }) }),
     });
     await modals.handleCodeModal(interaction, deps);
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Wrong code') }),
     );
   });
@@ -188,7 +188,7 @@ describe('umn_verify_code_modal', () => {
     });
     await modals.handleCodeModal(interaction, deps);
     expect(deps.postToOtpService).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('already verified') }),
     );
   });

--- a/src/bot/__tests__/handlers/setup.test.js
+++ b/src/bot/__tests__/handlers/setup.test.js
@@ -24,7 +24,7 @@ describe('/setup handler', () => {
     });
     const deps = createMockDeps();
     await setup.handle(interaction, deps);
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining("bot's role") }),
     );
     expect(deps.db.setGuildConfig).not.toHaveBeenCalled();
@@ -39,7 +39,7 @@ describe('/setup handler', () => {
     const deps = createMockDeps();
     await setup.handle(interaction, deps);
     expect(deps.db.setGuildConfig).toHaveBeenCalledWith('guild1', 'r1', 'r1');
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Setup complete') }),
     );
   });

--- a/src/bot/__tests__/handlers/verify.test.js
+++ b/src/bot/__tests__/handlers/verify.test.js
@@ -26,7 +26,7 @@ describe('/verify handler', () => {
     });
     await verify.handle(interaction, deps);
     expect(deps.postToOtpService).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('verified before') }),
     );
   });


### PR DESCRIPTION
Handlers had been refactored to call deferReply() first (to stay within Discord's 3-second deadline), then editReply() for the actual response. Tests were still asserting reply() — updated to editReply() for all async paths.
forget-me button handler uses deferUpdate() + editReply() instead of update() — factory got deferUpdate mock added, and the two confirm-button assertions updated to editReply.


The README has four updates:
CI badge — now points to ravindu-ranasinghe/Gopherfy (was the old repo name)
Schema — email_hmac TEXT UNIQUE replacing email TEXT UNIQUE, with prose explaining Gopherfy stores an HMAC-SHA256 digest instead of plaintext (no PII in the database)
Commands table — added /whois-audit (admins) and /forget-me (everyone)
Development section — documents npm run verify and the pre-push hook, added before the Authors